### PR TITLE
Realign buttons in Mail dialog after fix for 8.1

### DIFF
--- a/WardrobeTools/wardrobe/mailer.lua
+++ b/WardrobeTools/wardrobe/mailer.lua
@@ -385,7 +385,7 @@ local ResizePostalButtons = function()
 	if (not PostalSelectOpenButton or not PostalSelectReturnButton or PostalSelectOpenButton:GetWidth() == 76) then return; end
 
 	PostalSelectOpenButton:ClearAllPoints();
-	PostalSelectOpenButton:SetPoint("TOPLEFT", "MailFrame", "RIGHT", 0, -2);
+	PostalSelectOpenButton:SetPoint("TOPLEFT", "MailFrame", "TOPLEFT", 64, -30);
 	PostalSelectOpenButton:SetWidth(76);
 
 	PostalSelectReturnButton:SetWidth(76);


### PR DESCRIPTION
Firstly, this is my first time using GitHub... so I genuinely apologize if there's an accepted etiquette that I may not be following.

I've attempted to provide a code update to the mailer.lua to re-align the buttons into the MailFrame after the fix that was required after the WoW 8.1 release.

If I need to submit this suggestion differently, please let me know!

Thank you!!